### PR TITLE
DTSPO-5506 - change example port to one that isn't a privileged port

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Click `Create` in the Backstage sidebar and select [`Spring Boot Service`](https
       
    - Description:                   `Deploying a Java application`
 
-   - HTTP port:                     `80`
+   - HTTP port:                     `8080` - do not use any port number lower than 1024
 
    - GitHub admin team:             `hmcts/reform` - you can also use your own team
 


### PR DESCRIPTION
### Change description ###
- updating HTTP port value to 8080 as 80 doesn't work and could cause a bit of confusion

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
