### PR TITLE
Add guidance around GitHub topics for Jenkins

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,10 +51,12 @@ Click `Create` in the Backstage sidebar and select [`Spring Boot Service`](https
 
 ### Build application
 
+1. Go to your GitHub repository - there should be a link to it in backstage. Your repository needs an appropriate topic added in order for Jenkins to find it when it scans GitHub. Since your repository is called labs-yourGitHubUsername, you need to add the topic `jenkins-cft-j-z`
+
 1. Log in to Sandbox Jenkins and select [HMCTS - Labs](https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_LABS/) folder. Check if your repository is there, if it's not then scan the organization by clicking on `Scan Organization Now`.
 The new repository should be listed under repositories after the scan finishes.
 Logs can be monitored under `Scan Organization Log`.
-Any GitHub repository that starts with `labs-*` will be listed as part of this scan.
+Any GitHub repository that starts with `labs-*` and has the `jenkins-cft-j-z` topic will be listed as part of this scan.
 
 1. Click on your repository name.
 


### PR DESCRIPTION
### Change description ###
Flagged by someone on #golden-path
Don't know if it's possible to have this computed and then automatically added in https://github.com/hmcts/template-spring-boot/blob/c75f62418b004a6851561779cafa33302b5d89a8/template.yaml#L89 or not so updating the docs showing people how to add the required topic manually


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
